### PR TITLE
Don't fail when wrapping a function with no doc string

### DIFF
--- a/doctools.py
+++ b/doctools.py
@@ -5,6 +5,8 @@ from pprint import pformat
 
 def append_to_docs(fn, text):
     """Append text to a functions existing docblock."""
+    if not text:
+        return
     if fn.__doc__:
         min_indent = _getindent(fn.__doc__)
         fn.__doc__ = '%s\n\n%s' % (fn.__doc__, _indent(text, min_indent))

--- a/tests.py
+++ b/tests.py
@@ -58,7 +58,7 @@ def test_getindent_multiline_no_default_indent():
     assert _getindent("foo\nbar\n    baz") == 0
 
 
-def test_append_docs_from():
+def test_include_docs_from():
     def foo():
         """foo docs."""
 
@@ -67,6 +67,17 @@ def test_append_docs_from():
         """bar docs."""
 
     assert bar.__doc__ == 'bar docs.\n\nfoo docs.'
+
+
+def test_include_docs_from_undocumented():
+    def foo():
+        pass
+
+    @include_docs_from(foo)
+    def bar():
+        """bar docs."""
+
+    assert bar.__doc__ == 'bar docs.'
 
 
 


### PR DESCRIPTION
See title
